### PR TITLE
Fix form manager example

### DIFF
--- a/_includes/standard/form-manager.php
+++ b/_includes/standard/form-manager.php
@@ -4,8 +4,9 @@ public function newAction(Request $request)
 {
     $post = new BlogPost();
     $form = $this->createForm(new NewBlogPostType(), $post);
-
-    if (!$request->isMethodSafe() && $form->handleRequest($request) && $form->->isValid()) {
+    $form->handleRequest($request)
+    
+    if (!$request->isMethodSafe() && $form->isValid()) {
         $this->getDoctrine()->getManager()->persist($post);
         $this->getDoctrine()->getManager()->flush();
         $request->getSession()


### PR DESCRIPTION
- Fix typo (remove extra `->` when calling `$form->isValid()`)
- `Form::handleRequest` returns an instance of the Form class, which makes it useless in an `if` statement (since it will always evaluate to `true`)
